### PR TITLE
feat(cli): add `--purserl-version` flag

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,11 +12,13 @@ import qualified Command.Publish as Publish
 import qualified Command.REPL as REPL
 import           Control.Monad (join)
 import           Data.Foldable (fold)
+import qualified Data.Text as Text
 import qualified Options.Applicative as Opts
 import           System.Environment (getArgs)
 import qualified System.IO as IO
 import qualified Text.PrettyPrint.ANSI.Leijen as Doc
 import           Version (versionString)
+import qualified Language.PureScript.Version as PurserlVersion
 
 
 main :: IO ()
@@ -27,7 +29,7 @@ main = do
     IO.hSetBuffering IO.stderr IO.LineBuffering
     join $ Opts.handleParseResult . execParserPure opts =<< getArgs
   where
-    opts        = Opts.info (versionInfo <*> Opts.helper <*> commands) infoModList
+    opts        = Opts.info (versionInfo <*> purserlVersionInfo <*> Opts.helper <*> commands) infoModList
     infoModList = Opts.fullDesc <> headerInfo <> footerInfo
     headerInfo  = Opts.progDesc "The PureScript compiler and tools"
     footerInfo  = Opts.footerDoc (Just footer)
@@ -54,6 +56,10 @@ main = do
     versionInfo :: Opts.Parser (a -> a)
     versionInfo = Opts.abortOption (Opts.InfoMsg versionString) $
       Opts.long "version" <> Opts.help "Show the version number" <> Opts.hidden
+
+    purserlVersionInfo :: Opts.Parser (a -> a)
+    purserlVersionInfo = Opts.abortOption (Opts.InfoMsg (Text.unpack PurserlVersion.purserlVersionString)) $
+      Opts.long "purserl-version" <> Opts.help "Show the purserl version number" <> Opts.hidden
 
     commands :: Opts.Parser (IO ())
     commands =

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -18,7 +18,7 @@ import           System.Environment (getArgs)
 import qualified System.IO as IO
 import qualified Text.PrettyPrint.ANSI.Leijen as Doc
 import           Version (versionString)
-import qualified Language.PureScript.Version as PurserlVersion
+import qualified Language.PureScript.Erl as Purserl
 
 
 main :: IO ()
@@ -58,7 +58,7 @@ main = do
       Opts.long "version" <> Opts.help "Show the version number" <> Opts.hidden
 
     purserlVersionInfo :: Opts.Parser (a -> a)
-    purserlVersionInfo = Opts.abortOption (Opts.InfoMsg (Text.unpack PurserlVersion.purserlVersionString)) $
+    purserlVersionInfo = Opts.abortOption (Opts.InfoMsg (Text.unpack Purserl.versionString)) $
       Opts.long "purserl-version" <> Opts.help "Show the purserl version number" <> Opts.hidden
 
     commands :: Opts.Parser (IO ())

--- a/purerl/src/Language/PureScript/Erl.hs
+++ b/purerl/src/Language/PureScript/Erl.hs
@@ -1,1 +1,6 @@
 module Language.PureScript.Erl where
+
+import Data.Text (Text)
+
+versionString :: Text
+versionString = "S31"

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -399,6 +399,7 @@ library
     Language.PureScript.TypeChecker.Unify
     Language.PureScript.TypeClassDictionaries
     Language.PureScript.Types
+    Language.PureScript.Version
     System.IO.UTF8
     PrettyPrint
 

--- a/purescript.cabal
+++ b/purescript.cabal
@@ -430,6 +430,7 @@ library
     Language.PureScript.Erl.Pretty
     Language.PureScript.Erl.Run
     Language.PureScript.Erl.Synonyms
+    Language.PureScript.Erl
 
   other-modules:
     Data.Text.PureScript

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -76,7 +76,7 @@ import Language.PureScript.Roles as P
 import Language.PureScript.Sugar as P
 import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
-import Language.PureScript.Version as PurserlVersion
+import Language.PureScript.Erl as Purserl
 
 import Data.Maybe (catMaybes)
 
@@ -537,7 +537,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix mExternsMemCache =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage ("Compiling " <> PurserlVersion.purserlVersionString <> " ")
+  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage ("Compiling " <> Purserl.versionString <> " ")
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Make/Actions.hs
+++ b/src/Language/PureScript/Make/Actions.hs
@@ -76,6 +76,7 @@ import Language.PureScript.Roles as P
 import Language.PureScript.Sugar as P
 import Language.PureScript.TypeChecker as P
 import Language.PureScript.Types as P
+import Language.PureScript.Version as PurserlVersion
 
 import Data.Maybe (catMaybes)
 
@@ -536,7 +537,7 @@ buildMakeActions outputDir filePathMap foreigns usePrefix mExternsMemCache =
   requiresForeign = not . null . CF.moduleForeign
 
   progress :: ProgressMessage -> Make ()
-  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage "Compiling S31 "
+  progress = liftIO . TIO.hPutStr stderr . (<> "\n") . renderProgressMessage ("Compiling " <> PurserlVersion.purserlVersionString <> " ")
 
   readCacheDb :: Make CacheDb
   readCacheDb = readCacheDb' outputDir

--- a/src/Language/PureScript/Version.hs
+++ b/src/Language/PureScript/Version.hs
@@ -1,0 +1,9 @@
+module Language.PureScript.Version
+  ( purserlVersionString,
+  )
+where
+
+import Data.Text (Text)
+
+purserlVersionString :: Text
+purserlVersionString = "S31"

--- a/src/Language/PureScript/Version.hs
+++ b/src/Language/PureScript/Version.hs
@@ -1,9 +1,0 @@
-module Language.PureScript.Version
-  ( purserlVersionString,
-  )
-where
-
-import Data.Text (Text)
-
-purserlVersionString :: Text
-purserlVersionString = "S31"


### PR DESCRIPTION
I'd like to get `purserl` version info from the `purs` binary. This can now be queried via `--purserl-version`.
