### PR TITLE
fix crash for missing branch

### DIFF
--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -508,9 +508,9 @@ instance ToCS Expr () where
         toCS inExpr
 
       TypeClassDictionary _ _ _ -> internalError "[drathier]: should be unreachable, all TypeClassDictionary ctors should have been expanded already"
-      DeferredDictionary _ _ -> internalError "[drathier]should be unreachable, all DeferredDictionary ctors should have been expanded already"
-      DerivedInstancePlaceholder _ _ -> internalError "[drathier]should be unreachable, all DerivedInstancePlaceholder ctors should have been expanded already"
-      AnonymousArgument -> internalError "[drathier]: shshould be unreachable, all AnonymousArgument ctors should have been expanded already"
+      DeferredDictionary _ _ -> internalError "[drathier]: should be unreachable, all DeferredDictionary ctors should have been expanded already"
+      DerivedInstancePlaceholder _ _ -> internalError "[drathier]: should be unreachable, all DerivedInstancePlaceholder ctors should have been expanded already"
+      AnonymousArgument -> internalError "[drathier]: should be unreachable, all AnonymousArgument ctors should have been expanded already"
       Hole _ -> internalError "[drathier]: should be unreachable, all Hole ctors should have been expanded already"
       PositionedValue _ _ e -> toCS e
 

--- a/src/Language/PureScript/Externs.hs
+++ b/src/Language/PureScript/Externs.hs
@@ -479,6 +479,9 @@ instance ToCS Expr () where
       App e1 e2 -> do
         toCS e1
         toCS e2
+      VisibleTypeApp e sourceType -> do
+        toCS e
+        toCS sourceType
       Unused e -> toCS e
       Var _ qIdent -> csdbPutIdent qIdent
       Op _ qValueOpName -> csdbPutValueOp qValueOpName


### PR DESCRIPTION
**Description of the change**

I got the a crash due to an non-exhaustive pattern the first time I tried to export a proxy variable that had a VTA in it - it got sad real fast so I tried to fix it here.

---

**Checklist:**

- [ ] Added a file to CHANGELOG.d for this PR (see CHANGELOG.d/README.md)
- [ ] Added myself to CONTRIBUTORS.md (if this is my first contribution)
- [ ] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation
- [ ] Added a test for the contribution (if applicable)
